### PR TITLE
Fix to force usage of TLS V1.2

### DIFF
--- a/Auth0.IdinConnectorSample/Global.asax.cs
+++ b/Auth0.IdinConnectorSample/Global.asax.cs
@@ -75,6 +75,10 @@ namespace Auth0.IdinConnectorSample
 
         protected void Application_Start()
         {
+            // Fix to force TLS V1.2 usage, uncomment next line if you got errors
+            // like: "Could not create SSL/TLS secure channel."
+            // System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);


### PR DESCRIPTION
We had some problems with the new provider infrastructure that demanded TLS V1.2. This small fix made sure it works. It might be of some help to others.